### PR TITLE
Resolve Off-By-One Clip Yielding Problem

### DIFF
--- a/run_plax_hypertrophy_inference.py
+++ b/run_plax_hypertrophy_inference.py
@@ -331,7 +331,10 @@ class PlaxHypertrophyInferenceEngine:
             for p in batch_paths:
                 clips[p][1][batch_map[batch_map['path'] == p]['frame']] = preds[batch_map['path'] == p]
     
-
+        # Yield remaining clips
+        for k, v in clips.items():
+            yield Path(k), v[0], v[1]
+                
     def run_model_np(self, x: np.ndarray) -> np.ndarray:
         """Run inference on a numpy array video.
 


### PR DESCRIPTION
If you were to run the run_plax_hypertrophy_inference.py with just a single video as the target for inference, the _run_on_clips method fails to yield back the last set of clips. This small change avoids that "off-by-one" bug.

Nice work on this. <3